### PR TITLE
Protocol account

### DIFF
--- a/EthOn.rdf
+++ b/EthOn.rdf
@@ -2124,7 +2124,7 @@
     <owl:Class rdf:about="http://ethon.consensys.net/ProtocolAccount">
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/Account"/>
         <suggestedStringRepresentation xml:lang="en">PrefundedAccount</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A Protocol Account is an Account whose initial balance or other properties are defined in the protocol specification (ProtocolVariant) of the Blockchain. E.g. in the initial Ethereum Blockchain those that participated in the crowd funding received Accounts prefunded with their investment. However, Protocol Accounts could be added with any protocol change.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A Protocol Account is the third type of Account in Ethereum after External Accounts and Contract Accounts. Protocol Accounts are written into the Ethereum protocol, and are primarily used to store funds for users who participated in the Ethereum Crowdsale.</rdfs:comment>
         <rdfs:label xml:lang="en">Protocol Account</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>

--- a/EthOn.rdf
+++ b/EthOn.rdf
@@ -1936,7 +1936,7 @@
     <owl:Class rdf:about="http://ethon.consensys.net/ExternalAccount">
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/Account"/>
         <suggestedStringRepresentation xml:lang="en">ExternalAccount</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">An Account owned by an External Actor.</rdfs:comment>
+        <rdfs:comment xml:lang="en">One of three types of accounts on Ethereum, an External Account is an account owned by an External Actor. The majority of Ethereum accounts fall under this term.</rdfs:comment>
         <rdfs:label xml:lang="en">Externally controlled Account</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>


### PR DESCRIPTION
Maybe we can class protocol accounts as apriori only happening before the Ethereum launch. I don't think the devs or anyone could ever write in new protocol accounts without everyone calling shenanigans.