### PR TITLE
Lowercase

### DIFF
--- a/EthOn.rdf
+++ b/EthOn.rdf
@@ -106,7 +106,7 @@
 
     <owl:ObjectProperty rdf:about="http://ethon.consensys.net/AccountObjectProperty">
         <rdfs:subPropertyOf rdf:resource="http://ethon.consensys.net/EthOnObjectProperty"/>
-        <rdfs:comment xml:lang="en">Groups all EthOn Account Object Properties</rdfs:comment>
+        <rdfs:comment xml:lang="en">Groups all EthOn account object properties</rdfs:comment>
         <rdfs:label xml:lang="en">EthOn Account Object Property</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -117,7 +117,7 @@
 
     <owl:ObjectProperty rdf:about="http://ethon.consensys.net/BlockObjectProperty">
         <rdfs:subPropertyOf rdf:resource="http://ethon.consensys.net/EthOnObjectProperty"/>
-        <rdfs:comment xml:lang="en">Groups all EthOn Block Object Properties</rdfs:comment>
+        <rdfs:comment xml:lang="en">Groups all EthOn block object properties</rdfs:comment>
         <rdfs:label xml:lang="en">EthOn Block Object Property</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -127,7 +127,7 @@
     <!-- http://ethon.consensys.net/EthOnObjectProperty -->
 
     <owl:ObjectProperty rdf:about="http://ethon.consensys.net/EthOnObjectProperty">
-        <rdfs:comment xml:lang="en">Groups all EthOn Object Properties</rdfs:comment>
+        <rdfs:comment xml:lang="en">Groups all EthOn object properties</rdfs:comment>
         <rdfs:label xml:lang="en">EthOn Object Property</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -138,7 +138,7 @@
 
     <owl:ObjectProperty rdf:about="http://ethon.consensys.net/MessageObjectProperty">
         <rdfs:subPropertyOf rdf:resource="http://ethon.consensys.net/EthOnObjectProperty"/>
-        <rdfs:comment xml:lang="en">Groups all EthOn Message Object Properties.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Groups all EthOn message object properties.</rdfs:comment>
         <rdfs:label xml:lang="en">EthOn Message Object Property</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -149,7 +149,7 @@
 
     <owl:ObjectProperty rdf:about="http://ethon.consensys.net/NetworkObjectProperty">
         <rdfs:subPropertyOf rdf:resource="http://ethon.consensys.net/EthOnObjectProperty"/>
-        <rdfs:comment xml:lang="en">Groups all EthOn Network Object Properties.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Groups all EthOn network object properties.</rdfs:comment>
         <rdfs:label xml:lang="en">EthOn Network Object Property</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -160,7 +160,7 @@
 
     <owl:ObjectProperty rdf:about="http://ethon.consensys.net/StateObjectProperty">
         <rdfs:subPropertyOf rdf:resource="http://ethon.consensys.net/EthOnObjectProperty"/>
-        <rdfs:comment xml:lang="en">Groups all EthOn State Object Properties.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Groups all EthOn state object properties.</rdfs:comment>
         <rdfs:label xml:lang="en">EthOn State Object Property</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -173,7 +173,7 @@
         <rdfs:subPropertyOf rdf:resource="http://ethon.consensys.net/NetworkObjectProperty"/>
         <rdfs:domain rdf:resource="http://ethon.consensys.net/EthOnConcept"/>
         <suggestedStringRepresentation>conformsTo</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates an Ethereum concept to the Ethereum Protocol Variant it conforms to.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates an Ethereum concept to the Ethereum protocol variant it conforms to.</rdfs:comment>
         <rdfs:label>conforms to</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -188,7 +188,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Block"/>
         <rdfs:range rdf:resource="http://ethon.consensys.net/Tx"/>
         <suggestedStringRepresentation>containsTx</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Block to a Transaction included in it. All containsTx relations of a Block comprise the Block&apos;s transaction list. The order of the transactions is determined by their index value. The property is inverse functional because a Transaction can only be included in one Block.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a block to a transaction included in it. All containsTx relations of a block comprise the block&apos;s transaction list. The order of the transactions is determined by their index value. The property is inverse functional because a transaction can only be included in one block.</rdfs:comment>
         <rdfs:label xml:lang="en">contains Transaction</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -223,7 +223,7 @@
         </rdfs:domain>
         <rdfs:range rdf:resource="http://ethon.consensys.net/ContractAccount"/>
         <suggestedStringRepresentation>creates</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a create transaction to the ContractAccount it creates.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a create transaction to the contract account it creates.</rdfs:comment>
         <rdfs:label xml:lang="en">creates</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -239,7 +239,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Block"/>
         <rdfs:range rdf:resource="http://ethon.consensys.net/WorldState"/>
         <suggestedStringRepresentation>createsPostBlockState</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Block to the global state of the system after all Transactions in the Block have been executed.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a block to the global state of the system after all transactions in the block have been executed.</rdfs:comment>
         <rdfs:label xml:lang="en">creates post Block execution State</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -251,7 +251,7 @@
     <owl:ObjectProperty rdf:about="http://ethon.consensys.net/createsPostMsgState">
         <rdfs:subPropertyOf rdf:resource="http://ethon.consensys.net/createsState"/>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:comment>Relates a Message to the global state of the system after all the Message has been executed.</rdfs:comment>
+        <rdfs:comment>Relates a message to the global state of the system after all the message has been executed.</rdfs:comment>
         <rdfs:label>creates post Message execution State</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -266,7 +266,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Tx"/>
         <rdfs:range rdf:resource="http://ethon.consensys.net/WorldState"/>
         <suggestedStringRepresentation>createsPostTxState</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Transaction to the global state of the system after the Transaction has been executed.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a transaction to the global state of the system after the transaction has been executed.</rdfs:comment>
         <rdfs:label xml:lang="en">creates post Transaction execution State</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -281,7 +281,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/StateTransition"/>
         <rdfs:range rdf:resource="http://ethon.consensys.net/State"/>
         <suggestedStringRepresentation>createsState</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Transition to the State it creates.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a transition to the state it creates.</rdfs:comment>
         <rdfs:label xml:lang="en">creates State</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -293,7 +293,7 @@
     <owl:ObjectProperty rdf:about="http://ethon.consensys.net/from">
         <rdfs:subPropertyOf rdf:resource="http://ethon.consensys.net/MessageObjectProperty"/>
         <suggestedStringRepresentation>fromAccount</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Message with the Account it originates from.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a message to the account it originates from.</rdfs:comment>
         <rdfs:label xml:lang="en">from</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -308,7 +308,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty"/>
         <rdfs:range rdf:resource="http://ethon.consensys.net/AccountStorage"/>
         <suggestedStringRepresentation>hasAccountStorage</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates an Account to the Merkle Patricia tree that encodes its storage contents at a certain Account State. This property is Functional because an Account State can have only one Instance of Account Storage and Inverse Functional because an Account Storage can have only one associated Account State.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates an account to the Merkle Patricia tree that encodes its storage contents at a certain account state. This property is Functional because an account state can have only one instance of account storage and inverse functional because an account storage can have only one associated account state.</rdfs:comment>
         <rdfs:label xml:lang="en">has Account Storage</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -323,7 +323,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Block"/>
         <rdfs:range rdf:resource="http://ethon.consensys.net/Account"/>
         <suggestedStringRepresentation>hasBeneficiary</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Block to the Account to which all fees collected from the successful mining of this Block are transferred.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a block to the account to which all fees collected from the successful mining of this block are transferred.</rdfs:comment>
         <rdfs:label xml:lang="en">has beneficiary</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -353,7 +353,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Blockchain"/>
         <rdfs:range rdf:resource="http://ethon.consensys.net/Blockchain"/>
         <suggestedStringRepresentation>hasFork</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Blockchain to a forked version of it. It is inverse functional because a forked Blockchain can have only one Blockchain it forked from. It is Transitive because if a Blockchain C that was forked from Blockchain B that in turn was forked from Blockchain A, Blockchain C was also forked from Blockchain A. It is asymetric because if Blockchain A is forked from Blockchain B, B cannot be also forked from A. It is irreflexive because a Blockchain cannot be a fork of itself.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a blockchain to a forked version of it. It is inverse functional because a forked blockchain can have only one blockchain it forked from. It is transitive because if a blockchain C that was forked from blockchain B that in turn was forked from blockchain A, blockchain C was also forked from blockchain A. It is asymetric because if blockchain A is forked from blockchain B, B cannot be also forked from A. It is irreflexive because a blockchain cannot be a fork of itself.</rdfs:comment>
         <rdfs:label xml:lang="en">has Fork</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -367,7 +367,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Tx"/>
         <rdfs:range rdf:resource="http://ethon.consensys.net/LogEntry"/>
         <suggestedStringRepresentation>hasLogEntry</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Transaction to a Log Entry it creates.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a transaction to a log entry it creates.</rdfs:comment>
         <rdfs:label xml:lang="en">has Log Entry</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -381,7 +381,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/LogEntry"/>
         <rdfs:range rdf:resource="http://ethon.consensys.net/LogTopic"/>
         <suggestedStringRepresentation>hasLogTopic</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Log Entry to a Log Topic.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a log entry to a log topic.</rdfs:comment>
         <rdfs:label xml:lang="en">has Log Topic</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -396,7 +396,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/ContractMsg"/>
         <rdfs:range rdf:resource="http://ethon.consensys.net/Tx"/>
         <suggestedStringRepresentation>hasOriginatorTx</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Contract Message to the Transaction it originated from.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a contract message to the transaction it originated from.</rdfs:comment>
         <rdfs:label xml:lang="en">has Originator Transaction</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -413,7 +413,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Block"/>
         <rdfs:range rdf:resource="http://ethon.consensys.net/Block"/>
         <suggestedStringRepresentation>hasParentBlock</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Block to its parent in the chain. It always points to the Block with a number that is decreased by one, compared to the Block it originates from. The relation is asymmetric because if Block A is parent to Block B then Block B can not be parent to Block A. It is also irreflexive because a Block cannot be parent to itself.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a block to its parent in the chain. It always points to the block with a number that is decreased by one, compared to the block it originates from. The relation is asymmetric because if block A is parent to block B then block B can not be parent to block A. It is also irreflexive because a block cannot be parent to itself.</rdfs:comment>
         <rdfs:label xml:lang="en">has parent Block</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -441,7 +441,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty"/>
         <suggestedStringRepresentation>hasReceiptsTrie</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Block to the Trie that contains the Block&apos;s receipt data.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a block to the trie that contains the block&apos;s receipt data.</rdfs:comment>
         <rdfs:label xml:lang="en">has receipts trie</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -468,7 +468,7 @@
     <owl:ObjectProperty rdf:about="http://ethon.consensys.net/hasTransition">
         <rdfs:subPropertyOf rdf:resource="http://ethon.consensys.net/StateObjectProperty"/>
         <suggestedStringRepresentation>hasTransition</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a State to a Transition (i.e. a Message) that creates a new State.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a state to a transition (i.e. a message) that creates a new state.</rdfs:comment>
         <rdfs:label xml:lang="en">has Transition</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -484,7 +484,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Block"/>
         <rdfs:range rdf:resource="http://ethon.consensys.net/TxTrie"/>
         <suggestedStringRepresentation>hasTxTrie</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Block to the trie that contains the data of the transactions contained in the Block.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a block to the trie that contains the data of the transactions contained in the block.</rdfs:comment>
         <rdfs:label xml:lang="en">has transactions trie</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -496,7 +496,7 @@
     <owl:ObjectProperty rdf:about="http://ethon.consensys.net/knowsOfUncle">
         <rdfs:subPropertyOf rdf:resource="http://ethon.consensys.net/BlockObjectProperty"/>
         <suggestedStringRepresentation>knowsOfUncle</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Block to a known Uncle.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a block to a known uncle.</rdfs:comment>
         <rdfs:label xml:lang="en">knows of Uncle</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -510,7 +510,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/LogEntry"/>
         <rdfs:range rdf:resource="http://ethon.consensys.net/Account"/>
         <suggestedStringRepresentation>loggedBy</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Log Entry to its logger&apos;s Account.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a log entry to its logger&apos;s account.</rdfs:comment>
         <rdfs:label xml:lang="en">logged by</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -524,7 +524,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Node"/>
         <rdfs:range rdf:resource="http://ethon.consensys.net/Blockchain"/>
         <suggestedStringRepresentation>minesFor</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a mining Node to the Blockchain it mines for. Mining is the process of dedicating effort (working) to bolster one series of Transactions (a Block) over any other potential competitor Block. It is achieved thanks to a cryptographically secure proof.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a mining node to the blockchain it mines for. Mining is the process of dedicating effort (working) to bolster one series of transactions (a block) over any other potential competitor block. It is achieved thanks to a cryptographically secure proof.</rdfs:comment>
         <rdfs:label xml:lang="en">mines for</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -538,7 +538,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/PostBlockState"/>
         <rdfs:range rdf:resource="http://ethon.consensys.net/PostBlockState"/>
         <suggestedStringRepresentation>nextBlockState</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Post Block State to the following Post Block State.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a post block state to the following post block state.</rdfs:comment>
         <rdfs:label xml:lang="en">next Post Block State</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -552,7 +552,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/PostMsgState"/>
         <rdfs:range rdf:resource="http://ethon.consensys.net/PostMsgState"/>
         <suggestedStringRepresentation>nextMsgState</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Post Message State to the following Post Message State.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a post message state to the following post message state.</rdfs:comment>
         <rdfs:label xml:lang="en">next Post Message State</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -566,7 +566,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/WorldState"/>
         <rdfs:range rdf:resource="http://ethon.consensys.net/WorldState"/>
         <suggestedStringRepresentation>nextState</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a State to the following State. In EthOn the state transition system has no branches.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a state to the following state. In EthOn the state transition system has no branches.</rdfs:comment>
         <rdfs:label xml:lang="en">next State</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -580,7 +580,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/PostTxState"/>
         <rdfs:range rdf:resource="http://ethon.consensys.net/PostTxState"/>
         <suggestedStringRepresentation>nextTxState</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Post Transaction State to the following Post Transaction State.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a post transaction state to the following post transaction state.</rdfs:comment>
         <rdfs:label xml:lang="en">next Post Transaction State</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -609,7 +609,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/ContractAccount"/>
         <rdfs:range rdf:resource="http://ethon.consensys.net/Account"/>
         <suggestedStringRepresentation>refunds</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a SelfdestructContractMsg to the ContractAccount it sends its refund balance to.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a selfdestruct contract message to the contract account it sends its refund balance to.</rdfs:comment>
         <rdfs:label xml:lang="en">refunds</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -623,7 +623,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Node"/>
         <rdfs:range rdf:resource="http://ethon.consensys.net/Block"/>
         <suggestedStringRepresentation>spawnsBlock</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates an Ethereum Node to a valid Block it has transmitted to the network. This does not specify the proofing algorithm (e.g. proof of work or proof of authority).</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates an Ethereum node to a valid block it has transmitted to the network. This does not specify the proofing algorithm (e.g. proof of work or proof of authority).</rdfs:comment>
         <rdfs:label>spawns Block</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -637,7 +637,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Msg"/>
         <rdfs:range rdf:resource="http://ethon.consensys.net/Msg"/>
         <suggestedStringRepresentation>toAccount</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Message with the Account it is sent to.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a message with the account it is sent to.</rdfs:comment>
         <rdfs:label xml:lang="en">to</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>
@@ -660,7 +660,7 @@
         </rdfs:domain>
         <rdfs:range rdf:resource="http://ethon.consensys.net/ContractMsg"/>
         <suggestedStringRepresentation>triggersMsg</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Message that was direct to a Contract Account to the Contract Messages that result from the call to the Contract Account. The chain of triggersMsg relations represents a call graph.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a message that was direct to a contract account to the contract messages that result from the call to the contract account. The chain of triggersMsg relations represents a call graph.</rdfs:comment>
         <rdfs:label xml:lang="en">triggers Contract Message</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:ObjectProperty>

--- a/EthOn.rdf
+++ b/EthOn.rdf
@@ -1766,7 +1766,7 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <suggestedStringRepresentation>CallContractMsg</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A Call Contract Message is a Contract Message that calls a function in another Contract.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A call contract message is a contract message that calls a function in another contract.</rdfs:comment>
         <rdfs:label xml:lang="en">Call Contract Message</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -1780,7 +1780,7 @@
                 <owl:onClass rdf:resource="http://ethon.consensys.net/ContractAccount"/>
             </owl:Restriction>
         </owl:annotatedTarget>
-        <rdfs:comment>Call Contract Accounts call functions in other Contract Accounts.</rdfs:comment>
+        <rdfs:comment>Call contract accounts call functions in other contract accounts.</rdfs:comment>
     </owl:Axiom>
 
 
@@ -1797,7 +1797,7 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <suggestedStringRepresentation>CallTx</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A type of Transaction that is directed towards a Contract Account and calls a method in the Contract&apos;s code.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A type of transaction that is directed towards a contract account and calls a method in the contract&apos;s code.</rdfs:comment>
         <rdfs:label xml:lang="en">Call Transaction</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -1811,7 +1811,7 @@
                 <owl:onClass rdf:resource="http://ethon.consensys.net/ContractAccount"/>
             </owl:Restriction>
         </owl:annotatedTarget>
-        <rdfs:comment>Call transactions are directed towards a Contract Account.</rdfs:comment>
+        <rdfs:comment>Call transactions are directed towards a contract account.</rdfs:comment>
     </owl:Axiom>
 
 
@@ -1841,7 +1841,7 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <suggestedStringRepresentation>ContractMsg</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A Contract Message is passed between a Contract Account and any other Account (External or Contract). It is the result of an execution chain originally triggered by an External Account.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A contract message is passed between a contract account and any other account (external or contract). It is the result of an execution chain originally triggered by an external eccount.</rdfs:comment>
         <rdfs:label xml:lang="en">Contract Message</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -1855,7 +1855,7 @@
                 <owl:onClass rdf:resource="http://ethon.consensys.net/ContractAccount"/>
             </owl:Restriction>
         </owl:annotatedTarget>
-        <rdfs:comment>Contract Messages originate from Contract Accounts.</rdfs:comment>
+        <rdfs:comment>Contract messages originate from contract accounts.</rdfs:comment>
     </owl:Axiom>
 
 
@@ -1872,7 +1872,7 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <suggestedStringRepresentation>CreateContractMsg</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A Create Contract Message is a subtype of a Contract Message that results in creation of a new Contract Account.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A create contract message is a subtype of a contract message that results in creation of a new contract account.</rdfs:comment>
         <rdfs:label xml:lang="en">Create Contract Message</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -1886,7 +1886,7 @@
                 <owl:onClass rdf:resource="http://ethon.consensys.net/ContractAccount"/>
             </owl:Restriction>
         </owl:annotatedTarget>
-        <rdfs:comment>Create Contract Messages create Contract Accounts.</rdfs:comment>
+        <rdfs:comment>Create contract messages create contract accounts.</rdfs:comment>
     </owl:Axiom>
 
 
@@ -1903,7 +1903,7 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <suggestedStringRepresentation>CreateTx</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A type of Transaction that results in creation of a new Contract Account.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A type of transaction that results in creation of a new contract account.</rdfs:comment>
         <rdfs:label xml:lang="en">Create Transaction</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -1917,7 +1917,7 @@
                 <owl:onClass rdf:resource="http://ethon.consensys.net/ContractAccount"/>
             </owl:Restriction>
         </owl:annotatedTarget>
-        <rdfs:comment>All create transactions are directed toward a Contract Account they create.</rdfs:comment>
+        <rdfs:comment>All create transactions are directed toward a contract account they create.</rdfs:comment>
     </owl:Axiom>
 
 
@@ -1939,7 +1939,7 @@
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/Account"/>
         <simpleDefinition>An Ethereum account usually controlled by a person. It is identified by an address (0x...) and a public/private key-pair.</simpleDefinition>
         <suggestedStringRepresentation xml:lang="en">ExternalAccount</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">One of the two main types of Accounts on Ethereum, an External Account is an Account controlled by an External Actor (as opposed to a Contract Account). The unique identifier of an External Account is its address. It consists of the rightmost 160 bits of the keccak 256 hash of its public key (Example: 0x1a1138875dAB9E0AC8b0fd4a37EEAC5eb26B870B). There is only one way External Accounts can actively change the state of the blockchain. They can be used to send a valid Transaction to the Ethereum blockchain. The transaction can be directed towards other External Accounts or towards Contract Accounts. Since the private key is needed for sending, a valid Transaction can only be created by the person or entity controlling the private key of the External Account. Besides being target of Transactions, External Accounts can also be the target of Contract Messages, Block beneficiary rewards, Uncle beneficiary rewards or payouts of Contract Accounts that have self-destructed.</rdfs:comment>
+        <rdfs:comment xml:lang="en">One of the two main types of accounts on Ethereum, an external account is an account controlled by an external actor (as opposed to a contract account). The unique identifier of an external account is its address. It consists of the rightmost 160 bits of the keccak 256 hash of its public key (example: 0x1a1138875dAB9E0AC8b0fd4a37EEAC5eb26B870B). There is only one way external accounts can actively change the state of the blockchain. They can be used to send a valid transaction to the Ethereum blockchain. The transaction can be directed towards other external accounts or towards contract accounts. Since the private key is needed for sending, a valid transaction can only be created by the person or entity controlling the private key of the external account. Besides being target of transactions, external accounts can also be the target of contract messages, block beneficiary rewards, uncle beneficiary rewards or payouts of contract accounts that have self-destructed.</rdfs:comment>
         <rdfs:label xml:lang="en">Externally Controlled Account</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -1952,7 +1952,7 @@
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/AccountConcept"/>
         <rdfs:subClassOf rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
         <suggestedStringRepresentation xml:lang="en">ExternalActor</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A person or other entity able to interface to an Ethereum node, but External to the world of Ethereum. It can interact with Ethereum through depositing signed Transactions and inspecting the Blockchain and associated state. Has one (or more) intrinsic Accounts. While it is assumed that the ultimate External actor will be human in nature, software tools will be used in its construction and dissemination.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A person or other entity able to interface to an Ethereum node, but external to the world of Ethereum. It can interact with Ethereum through depositing signed transactions and inspecting the blockchain and associated state. Has one (or more) intrinsic accounts. While it is assumed that the ultimate external actor will be human in nature, software tools will be used in its construction and dissemination.</rdfs:comment>
         <rdfs:label xml:lang="en">External Actor</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -1965,7 +1965,7 @@
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/Node"/>
         <owl:disjointWith rdf:resource="http://ethon.consensys.net/LightNode"/>
         <suggestedStringRepresentation>FullNode</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A Full Node is a participant in an Ethereum Network that keeps a record of the full Blockchain, the full state and engages in mining.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A full node is a participant in an Ethereum network that keeps a record of the full blockchain, the full state and engages in mining.</rdfs:comment>
         <rdfs:label xml:lang="en">Ethereum Full Node</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -1977,7 +1977,7 @@
     <owl:Class rdf:about="http://ethon.consensys.net/GenesisBlock">
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/Block"/>
         <suggestedStringRepresentation>GenesisBlock</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A Genesis Block is the unmined, deliberately created, very first Block in a Blockchain. It has no predecessors, i.e. no parent Block.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A genesis block is the unmined, deliberately created, very first block in a blockchain. It has no predecessors, i.e. no parent block.</rdfs:comment>
         <rdfs:label xml:lang="en">Genesis Block</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -1989,7 +1989,7 @@
     <owl:Class rdf:about="http://ethon.consensys.net/LightNode">
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/Node"/>
         <suggestedStringRepresentation>LightNode</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A light node is a participant in an Ethereum Network that does not completely do any of the following: store the complete Blockchain, store the complete world state, engage in mining.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A light node is a participant in an Ethereum network that does not completely do any of the following: store the complete blockchain, store the complete world state, engage in mining.</rdfs:comment>
         <rdfs:label xml:lang="en">Ethereum Light Node</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -2001,7 +2001,7 @@
     <owl:Class rdf:about="http://ethon.consensys.net/LogEntry">
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/MessageConcept"/>
         <suggestedStringRepresentation>LogEntry</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A LogEntry is the result of an Event in a smart contract, emitted during creation or execution of a ContracAccount&apos;s code. It is related to the TxReceipt it was created in, the ContractAccount that had the Event, a series of 32-bytes Log Topics and a number of bytes of data.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A log ntry is the result of an event in a smart contract, emitted during creation or execution of a contract account&apos;s code. It is related to the TxReceipt it was created in, the contract account that had the event, a series of 32-bytes log topics and a number of bytes of data.</rdfs:comment>
         <rdfs:label xml:lang="en">Log Entry</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -2013,7 +2013,7 @@
     <owl:Class rdf:about="http://ethon.consensys.net/LogTopic">
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/MessageConcept"/>
         <suggestedStringRepresentation>LogTopic</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A 32-bytes long topic of a LogEntry. The LogTopics of a LogEntry have an order given by a topicIndex value.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A 32-bytes long topic of a log entry. The log topics of a log entry have an order given by a topic index value.</rdfs:comment>
         <rdfs:label xml:lang="en">Log Topic</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>

--- a/EthOn.rdf
+++ b/EthOn.rdf
@@ -683,7 +683,7 @@
     <owl:DatatypeProperty rdf:about="http://ethon.consensys.net/AccountDataProperty">
         <rdfs:subPropertyOf rdf:resource="http://ethon.consensys.net/EthOnDataProperty"/>
         <rdfs:domain rdf:resource="http://ethon.consensys.net/AccountConcept"/>
-        <rdfs:comment xml:lang="en">Groups all Data Properties that are specific to an Account.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Groups all data properties that are specific to an account.</rdfs:comment>
         <rdfs:label xml:lang="en">EthOn Account Data Property</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -695,7 +695,7 @@
     <owl:DatatypeProperty rdf:about="http://ethon.consensys.net/BlockDataProperty">
         <rdfs:subPropertyOf rdf:resource="http://ethon.consensys.net/EthOnDataProperty"/>
         <rdfs:domain rdf:resource="http://ethon.consensys.net/BlockConcept"/>
-        <rdfs:comment xml:lang="en">Groups all Data Properties that are specific to a Block. These properties are usually functional because a Block can only be associated with a single instance of them.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Groups all data properties that are specific to a block. These properties are usually functional because a block can only be associated with a single instance of them.</rdfs:comment>
         <rdfs:label xml:lang="en">EthOn Block Data Property</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -706,7 +706,7 @@
 
     <owl:DatatypeProperty rdf:about="http://ethon.consensys.net/EthOnDataProperty">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
-        <rdfs:comment xml:lang="en">Groups all Data Properties specific to EthOn.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Groups all data properties specific to EthOn.</rdfs:comment>
         <rdfs:label xml:lang="en">EthOn Data Property</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -718,7 +718,7 @@
     <owl:DatatypeProperty rdf:about="http://ethon.consensys.net/MessageDataProperty">
         <rdfs:subPropertyOf rdf:resource="http://ethon.consensys.net/EthOnDataProperty"/>
         <rdfs:domain rdf:resource="http://ethon.consensys.net/MessageConcept"/>
-        <rdfs:comment xml:lang="en">Groups all EthOn Message Data Properties.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Groups all EthOn message data properties.</rdfs:comment>
         <rdfs:label>EthOn Message Data Property</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -729,7 +729,7 @@
 
     <owl:DatatypeProperty rdf:about="http://ethon.consensys.net/NetworkDataProperty">
         <rdfs:subPropertyOf rdf:resource="http://ethon.consensys.net/EthOnDataProperty"/>
-        <rdfs:comment xml:lang="en">Groups all EthOn Network Data Properties.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Groups all EthOn network data properties.</rdfs:comment>
         <rdfs:label xml:lang="en">EthOn Network Data Property</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -753,7 +753,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/AccountState"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <suggestedStringRepresentation>accountBalance</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A scalar value equal to the number of Wei owned by an Account at a given Account state.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A scalar value equal to the number of Wei owned by an account at a given account state.</rdfs:comment>
         <rdfs:label xml:lang="en">Account balance</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -767,7 +767,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/ProtocolAccount"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <suggestedStringRepresentation>accountBalancePrefunded</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">The amount of Wei an Account was prefunded with in a Protocol Variant. In the case that an Account receives multiple prefunds in multiple Protocol Variants, the amounts are summed. In contrast to the regular Account balance it is a property of the Account itself and not of its state.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The amount of Wei an account was prefunded with in a protocol variant. In the case that an account receives multiple prefunds in multiple protocol variants, the amounts are summed. In contrast to the regular account balance it is a property of the account itself and not of its state.</rdfs:comment>
         <rdfs:label xml:lang="en">Account balance prefunded</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -782,7 +782,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/ContractAccount"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#base64Binary"/>
         <suggestedStringRepresentation>accountCode</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">The immutable EVM bytecode of the Contract Account.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The immutable EVM bytecode of the contract account.</rdfs:comment>
         <rdfs:label xml:lang="en">Account code</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -797,7 +797,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/ContractAccount"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#base64Binary"/>
         <suggestedStringRepresentation>accountCodeHash</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">The immutable Keccak-256 hash of the EVM code of an Account.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The immutable Keccak-256 hash of the EVM code of an account.</rdfs:comment>
         <rdfs:label xml:lang="en">Account code hash</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -812,7 +812,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/AccountState"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <suggestedStringRepresentation>accountNonce</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A scalar value equal to the number of transactions sent from this Account or, in the case of Accounts with associated code, the number of Contract-creations made by this Account.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A scalar value equal to the number of transactions sent from this account or, in the case of accounts with associated code, the number of contract-creations made by this account.</rdfs:comment>
         <rdfs:label xml:lang="en">Account nonce</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -827,7 +827,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/ExternalAccount"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#hexBinary"/>
         <suggestedStringRepresentation>accountPublicKey</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">The public key of an ExternalAccount.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The public key of an external account.</rdfs:comment>
         <rdfs:label xml:lang="en">Account public key</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -842,7 +842,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Account"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#hexBinary"/>
         <suggestedStringRepresentation>address</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A 160-bit identifier for Accounts.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A 160-bit identifier for accounts.</rdfs:comment>
         <rdfs:label xml:lang="en">Address</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -879,7 +879,7 @@
         </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
         <suggestedStringRepresentation>blockCreationTime</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">This Block&apos;s inception date and time.</rdfs:comment>
+        <rdfs:comment xml:lang="en">This block&apos;s inception date and time.</rdfs:comment>
         <rdfs:label xml:lang="en">Block creation time</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -901,7 +901,7 @@
         </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <suggestedStringRepresentation>blockDifficulty</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A scalar value corresponding to the difficulty level of this Block. This can be calculated from the previous Block&apos;s difficulty level and the timestamp.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A scalar value corresponding to the difficulty level of this block. This can be calculated from the previous block&apos;s difficulty level and the timestamp.</rdfs:comment>
         <rdfs:label xml:lang="en">Block difficulty</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -923,7 +923,7 @@
         </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#hexBinary"/>
         <suggestedStringRepresentation>blockExtraData</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">An arbitrary byte array containing data relevant to this Block. This must be 32 bytes or fewer.</rdfs:comment>
+        <rdfs:comment xml:lang="en">An arbitrary byte array containing data relevant to this block. This must be 32 bytes or fewer.</rdfs:comment>
         <rdfs:label xml:lang="en">Block extra data</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -945,7 +945,7 @@
         </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <suggestedStringRepresentation>blockGasLimit</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A scalar value equal to the current limit of gas expenditure per Block.  Its purpose is to keep block propagation and processing time low, thereby allowing for a sufficiently decentralized network. Miners have the option to increase or decrease it every block by a certain factor.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A scalar value equal to the current limit of gas expenditure per block.  Its purpose is to keep block propagation and processing time low, thereby allowing for a sufficiently decentralized network. Miners have the option to increase or decrease it every block by a certain factor.</rdfs:comment>
         <rdfs:label xml:lang="en">Block gas limit</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -967,7 +967,7 @@
         </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <suggestedStringRepresentation>blockGasUsed</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A scalar value equal to the total gas used by all Transactions in this Block.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A scalar value equal to the total gas used by all transactions in this block.</rdfs:comment>
         <rdfs:label xml:lang="en">Block gas used</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -989,7 +989,7 @@
         </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#hexBinary"/>
         <suggestedStringRepresentation>blockHash</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">The Keccak 256-bit hash of the Block&apos;s header, in its entierty.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The Keccak 256-bit hash of the block&apos;s header, in its entierty.</rdfs:comment>
         <rdfs:label xml:lang="en">Block hash</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1011,7 +1011,7 @@
         </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#hexBinary"/>
         <suggestedStringRepresentation>blockHeader</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Block to its Block header data. The Block header data contains 15 pieces of information: 1. the parent hash, 2. the Uncle hash, 3. a beneficiary address, 4. a state root hash, 5. a transactions root hash, 6. a receipts root hash, 7. a log bloom filter, 8. the difficulty value, 9. the Block number, 10. the gas limit of the Block, 11. the gas used by all transactions in the Block, 12. a scalar timestamp in unix time() format, 13. a byte array containing extra data, 14. a mix hash and 15. the Block nonce. The property is functional because a Block can have only exactly one Block header.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a block to its block header data. The block header data contains 15 pieces of information: 1. the parent hash, 2. the Uncle hash, 3. a beneficiary address, 4. a state root hash, 5. a transactions root hash, 6. a receipts root hash, 7. a log bloom filter, 8. the difficulty value, 9. the block number, 10. the gas limit of the block, 11. the gas used by all transactions in the block, 12. a scalar timestamp in unix time() format, 13. a byte array containing extra data, 14. a mix hash and 15. the block nonce. The property is functional because a block can have only exactly one block header.</rdfs:comment>
         <rdfs:label xml:lang="en">Block header</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1055,7 +1055,7 @@
         </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#hexBinary"/>
         <suggestedStringRepresentation>blockMixHash</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A 256-bit hash which proves combined with the nonce that a sufficient amount of computation has been carried out on this Block.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A 256-bit hash which proves combined with the nonce that a sufficient amount of computation has been carried out on this block.</rdfs:comment>
         <rdfs:label xml:lang="en">Block mix hash</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1077,7 +1077,7 @@
         </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#hexBinary"/>
         <suggestedStringRepresentation>blockNonce</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A 64 bit hash which proves combined with the mix-hash that a sufficient amount of computation has been carried out on this Block.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A 64 bit hash which proves combined with the mix-hash that a sufficient amount of computation has been carried out on this block.</rdfs:comment>
         <rdfs:label xml:lang="en">Block nonce</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1092,7 +1092,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Block"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <suggestedStringRepresentation>blockSize</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">The size of the the Block header in RLP format in bytes.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The size of the block header in RLP format in bytes.</rdfs:comment>
         <rdfs:label xml:lang="en">Block size</rdfs:label>
         <rdfs:seeAlso rdf:resource="https://github.com/ethereum/wiki/wiki/RLP"/>
         <ns:term_status>unstable</ns:term_status>
@@ -1107,7 +1107,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Node"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <suggestedStringRepresentation>clientVersion</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Node to a string identifying the Ethereum client version it runs. It composed of the client name (e.g. Geth) and a version identifier (e.g. v1.5.4).</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a node to a string identifying the Ethereum client version it runs. It composed of the client name (e.g. Geth) and a version identifier (e.g. v1.5.4).</rdfs:comment>
         <rdfs:label xml:lang="en">runs client</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1121,7 +1121,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Tx"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <suggestedStringRepresentation>cumulativeGasUsed</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">The cumulative gas used in the block containing the Transaction as of immediately after the Transaction has happened.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The cumulative gas used in the block containing the transaction as of immediately after the transaction has happened.</rdfs:comment>
         <rdfs:label xml:lang="en">cumulative gas used</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1135,7 +1135,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/LogEntry"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#hexBinary"/>
         <suggestedStringRepresentation>logData</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Log Entry to its data.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a log entry to its data.</rdfs:comment>
         <rdfs:label xml:lang="en">Log data</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1150,7 +1150,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Tx"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <suggestedStringRepresentation>logIndex</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Log Entry to its index in the transaction reciept of a Transaction. The log index defines the order of the Log Entries of a Transaction.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a log entry to its index in the transaction reciept of a transaction. The log index defines the order of the log entries of a transaction.</rdfs:comment>
         <rdfs:label xml:lang="en">Log index</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1165,7 +1165,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/LogTopic"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#hexBinary"/>
         <suggestedStringRepresentation>logTopicData</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Log Topic to the 32 bytes of data it contains.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a log topic to the 32 bytes of data it contains.</rdfs:comment>
         <rdfs:label xml:lang="en">Log Topic data</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1180,7 +1180,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/LogTopic"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <suggestedStringRepresentation>logTopicIndex</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Log Topic to its index in the Log Entry. The Log Topic index defines the order of the Log Topics of in Log Entry.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a log topic to its index in the log entry. The log topic index defines the order of the log topics of in log entry.</rdfs:comment>
         <rdfs:label xml:lang="en">Log Topic index</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1194,7 +1194,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Tx"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <suggestedStringRepresentation>msgCallDepth</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A scalar value equal to the depth of the Contract Message. A Contract Message is represented as a Call in the Ethereum EVM. This value represents the number of CALL or CREATE opcodes being executed at the time of the Message execution.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A scalar value equal to the depth of the contract message. A contract message is represented as a call in the Ethereum EVM. This value represents the number of CALL or CREATE opcodes being executed at the time of the message execution.</rdfs:comment>
         <rdfs:label xml:lang="en">Message call depth</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1230,7 +1230,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/ContractMsg"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
         <suggestedStringRepresentation>msgError</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A boolean value indicating whether the ContractMessage execution resulted in an error. A &quot;true&quot; value indicates an error.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A boolean value indicating whether the contract message execution resulted in an error. A &quot;true&quot; value indicates an error.</rdfs:comment>
         <rdfs:label xml:lang="en">Message error</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1245,7 +1245,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/ContractMsg"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <suggestedStringRepresentation>msgErrorString</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A string informally describing an error that occured during the execution of a ContractMessage. Only exists if msgError is true.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A string informally describing an error that occured during the execution of a contract message. Only exists if msgError is true.</rdfs:comment>
         <rdfs:label xml:lang="en">Message error string</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1259,7 +1259,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Msg"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <suggestedStringRepresentation>msgGasLimit</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A scalar value equal to the maximum amount of gas that should be used in executing this transaction. This is paid up-front, before any computation is done and may not be increased later. If used with Contract Messages it represents the fraction of the original Transaction gas limit still available for execution of the Contract Message. After all resulting computations are done, excess gas is returned to the sender of the original Transaction.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A scalar value equal to the maximum amount of gas that should be used in executing this transaction. This is paid up-front, before any computation is done and may not be increased later. If used with contract messages it represents the fraction of the original transaction gas limit still available for execution of the contract message. After all resulting computations are done, excess gas is returned to the sender of the original transaction.</rdfs:comment>
         <rdfs:label xml:lang="en">Message gas limit</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1275,7 +1275,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <owl:propertyDisjointWith rdf:resource="http://ethon.consensys.net/txGasUsed"/>
         <suggestedStringRepresentation>msgGasUsed</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">The amount of gas that was used for processing a single Message, regardless of which type of Message it may be.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The amount of gas that was used for processing a single message, regardless of which type of message it may be.</rdfs:comment>
         <rdfs:label xml:lang="en">Msg gas used</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1296,7 +1296,7 @@
         </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#hexBinary"/>
         <suggestedStringRepresentation>msgInit</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">An unlimited size byte array specifying the EVM-code for the Contract Account initialisation procedure.</rdfs:comment>
+        <rdfs:comment xml:lang="en">An unlimited size byte array specifying the EVM-code for the contract account initialisation procedure.</rdfs:comment>
         <rdfs:label xml:lang="en">Message init code</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1311,7 +1311,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/CallContractMsg"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#hexBinary"/>
         <suggestedStringRepresentation>msgOutput</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">The reulting output data from a CallContractMsg.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The reulting output data from a call contract message.</rdfs:comment>
         <rdfs:label xml:lang="en">Message output</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1326,7 +1326,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Msg"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#hexBinary"/>
         <suggestedStringRepresentation>msgPayload</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">An unlimited size byte array specifying the data payload of the Message.</rdfs:comment>
+        <rdfs:comment xml:lang="en">An unlimited size byte array specifying the data payload of the message.</rdfs:comment>
         <rdfs:label xml:lang="en">Message payload</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1341,7 +1341,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/SelfdestructContractMsg"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <suggestedStringRepresentation>msgRefundBalance</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A scalar value equal to the number of Wei that will be refunded in result of the SelfdestructContractMsg.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A scalar value equal to the number of Wei that will be refunded as the result of a selfdestruct contract message.</rdfs:comment>
         <rdfs:label xml:lang="en">contract balance in Wei</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1363,7 +1363,7 @@
         </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <suggestedStringRepresentation>number</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A scalar value equal to the number of ancestor Blocks. The genesis Block has a number of zero.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A scalar value equal to the number of ancestor blocks. The genesis block has a number of zero.</rdfs:comment>
         <rdfs:label xml:lang="en">Block number</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1378,7 +1378,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/ReceiptsTrie"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#hexBinary"/>
         <suggestedStringRepresentation>blockReceiptsRoot</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">The Keccak 256-bit hash of the root node of the trie structure populated with the receipts of each transaction in the transactions list portion of the Block.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The Keccak 256-bit hash of the root node of the trie structure populated with the receipts of each transaction in the transactions list portion of the block.</rdfs:comment>
         <rdfs:label xml:lang="en">Receipts root</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1392,7 +1392,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Blockchain"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <suggestedStringRepresentation>startBlockNumber</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">The Block number of the first block in a new Blockchain after a hard fork.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The block number of the first block in a new blockchain after a hard fork.</rdfs:comment>
         <rdfs:label xml:lang="en">start Block number</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1422,7 +1422,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/AccountStorage"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#base64Binary"/>
         <suggestedStringRepresentation>storageRoot</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A 256-bit hash of the root node of a Merkle Patricia tree that encodes the storage contents of the Account (a mapping between 265-bit integer values), encoded into the trie as a mapping from the Keccak 256-bit hash of the 256-bit integer keys to the RLP-encoded 256-bit integer values.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A 256-bit hash of the root node of a Merkle Patricia tree that encodes the storage contents of the account (a mapping between 265-bit integer values), encoded into the trie as a mapping from the Keccak 256-bit hash of the 256-bit integer keys to the RLP-encoded 256-bit integer values.</rdfs:comment>
         <rdfs:label xml:lang="en">Storage root</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1437,7 +1437,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/TxTrie"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#hexBinary"/>
         <suggestedStringRepresentation>blockTransactionsRoot</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">The Keccak 256-bit hash of the root node of the trie structure populated with each transaction in the transactions list portion of the Block.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The Keccak 256-bit hash of the root node of the trie structure populated with each transaction in the transactions list portion of the block.</rdfs:comment>
         <rdfs:label xml:lang="en">Transactions root</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1451,7 +1451,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Tx"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <suggestedStringRepresentation>txGasPrice</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A scalar value equal to the number of Wei to be paid per unit of gas for all computation costs incurred as a result of the execution of this Transaction.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A scalar value equal to the number of Wei to be paid per unit of gas for all computation costs incurred as a result of the execution of this transaction.</rdfs:comment>
         <rdfs:label xml:lang="en">Transaction gas price</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1466,7 +1466,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Tx"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <suggestedStringRepresentation>txGasUsed</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">The total amount of gas that was used for processing this Tx and all ContractMessages resulting from it. It is the sum of all msgGasUsed by this Tx and resulting ContractMessages.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The total amount of gas that was used for processing this Tx and all contract messages resulting from it. It is the sum of all msgGasUsed by this Tx and resulting contract messages.</rdfs:comment>
         <rdfs:label xml:lang="en">Tx gas used</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1480,7 +1480,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Tx"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#hexBinary"/>
         <suggestedStringRepresentation>txHash</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">The Keccak 256-bit hash of the Transaction</rdfs:comment>
+        <rdfs:comment xml:lang="en">The Keccak 256-bit hash of the transaction</rdfs:comment>
         <rdfs:label xml:lang="en">Tx hash</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1494,7 +1494,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Tx"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <suggestedStringRepresentation>txIndex</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">The position of a Transaction in a Block.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The position of a transaction in a block.</rdfs:comment>
         <rdfs:label xml:lang="en">Transaction index</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1508,7 +1508,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Tx"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#hexBinary"/>
         <suggestedStringRepresentation>txLogsBloom</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Relates a Transaction to the Bloom filter of its Log Entries.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Relates a transaction to the Bloom filter of its log entries.</rdfs:comment>
         <rdfs:label xml:lang="en">Transaction Logs Bloom filter</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1580,7 +1580,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Uncle"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <suggestedStringRepresentation>uncleBenficiaryReward</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">The reward the beneficiary of an uncle receives if a Block includes it. The reward amount depends how far up the Uncle is in the blockchain (the number of the Block in which it is included minus the Uncle&apos;s number). An uncle reward is only paid if the distance is smaller than 8. For a distance of 1 the reward is 7/8 of the block reward, for a distance of 7 the reward is 1/8 of the block reward.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The reward the beneficiary of an uncle receives if a block includes it. The reward amount depends how far up the Uncle is in the blockchain (the number of the block in which it is included minus the uncle&apos;s number). An uncle reward is only paid if the distance is smaller than 8. For a distance of 1 the reward is 7/8 of the block reward, for a distance of 7 the reward is 1/8 of the block reward.</rdfs:comment>
         <rdfs:label xml:lang="en">Uncle beneficiary reward</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>
@@ -1595,7 +1595,7 @@
         <rdfs:domain rdf:resource="http://ethon.consensys.net/Msg"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
         <suggestedStringRepresentation>value</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A scalar value equal to the number of Wei to be transferred to the Message call&apos;s recipient. In the case of Contract creation it is the initial balance of the Contract Account, paid by the sending Account.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A scalar value equal to the number of Wei to be transferred to the Message call&apos;s recipient. In the case of contract creation it is the initial balance of the contract account, paid by the sending account.</rdfs:comment>
         <rdfs:label xml:lang="en">value in Wei</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:DatatypeProperty>

--- a/EthOn.rdf
+++ b/EthOn.rdf
@@ -71,7 +71,7 @@
         <rdfs:subPropertyOf rdf:resource="http://ethon.consensys.net/EthOnAnnotationProperty"/>
         <rdfs:domain rdf:resource="http://ethon.consensys.net/EthOnConcept"/>
     </owl:AnnotationProperty>
-    
+
 
 
     <!-- http://ethon.consensys.net/suggestedStringRepresentation -->
@@ -1666,7 +1666,7 @@
     <owl:Class rdf:about="http://ethon.consensys.net/AccountConcept">
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/EthOnConcept"/>
         <suggestedStringRepresentation xml:lang="en">AccountConcept</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">The concept under which fall all account concepts, including External Accounts, Protocol Accounts, and Contract Accounts.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The concept under which fall all account concepts, including external accounts, protocol accounts, and contract accounts.</rdfs:comment>
         <rdfs:label xml:lang="en">EthOn Account concept</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -1679,7 +1679,7 @@
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/AccountConcept"/>
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/State"/>
         <suggestedStringRepresentation xml:lang="en">AccountState</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">State of an Ethereum Account. It is comprised on four pieces of information: nonce, balance, storage root and code hash. The data is stored in a Merkle Patricia tree as a mapping between addresses and Account states. The Account State is part of the World State, as it resembles the state of exactly one Account.</rdfs:comment>
+        <rdfs:comment xml:lang="en">State of an Ethereum account. It is comprised on four pieces of information: nonce, balance, storage root and code hash. The data is stored in a Merkle Patricia tree as a mapping between addresses and account states. The account state is part of the world state, as it resembles the state of exactly one account.</rdfs:comment>
         <rdfs:label xml:lang="en">Account State</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -1692,7 +1692,7 @@
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/AccountConcept"/>
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/ModifiedMerklePatriciaTree"/>
         <suggestedStringRepresentation xml:lang="en">AccountStorage</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A Merkle Patricia tree that encodes the storage contents of an Account. It is not used to store an Account&apos;s code, but the execution state of the code. The Account&apos;s code is stored in the</rdfs:comment>
+        <rdfs:comment xml:lang="en">A Merkle Patricia tree that encodes the storage contents of an account. It is not used to store an account&apos;s code, but the execution state of the code. The account&apos;s code is stored in the</rdfs:comment>
         <rdfs:label xml:lang="en">Storage</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -1707,9 +1707,9 @@
         <owl:hasKey rdf:parseType="Collection">
             <rdf:Description rdf:about="http://ethon.consensys.net/blockHash"/>
         </owl:hasKey>
-        <simpleDefinition>A Block is an entry in a Blockchain. It contains a series of transactions as well as a cryptographic hash linking it to the previous Block in the chain.</simpleDefinition>
+        <simpleDefinition>A block is an entry in a blockchain. It contains a series of transactions as well as a cryptographic hash linking it to the previous block in the chain.</simpleDefinition>
         <suggestedStringRepresentation xml:lang="en">Block</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A Block is the basic element of a &apos;Blockchain&apos;. It functions as an entry in a distributed ledger, recording a series of Transactions together with a reference to the previous Block. A Block is chained to its preceeding Block by a cryptographic hash of its contents as a means of reference. Blocks contain an identifier for the final state after all transactions contained in it are validated. There is a consensus mechanism that provides incentives for Nodes adding new Blocks to the Chain (&quot;miners&quot; in the Proof of Work protocol used by the main Ethereum network) that comply with the rules of Ethereum by issuing newly generated tokens (&apos;Ether&apos;) to an Account specified by the Block's author.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A block is the basic element of a &apos;blockchain&apos;. It functions as an entry in a distributed ledger, recording a series of transactions together with a reference to the previous block. A block is chained to its preceeding block by a cryptographic hash of its contents as a means of reference. Blocks contain an identifier for the final state after all transactions contained in it are validated. There is a consensus mechanism that provides incentives for nodes adding new blocks to the chain (&quot;miners&quot; in the Proof of Work protocol used by the main Ethereum network) that comply with the rules of Ethereum by issuing newly generated tokens (&apos;Ether&apos;) to an account specified by the block's author.</rdfs:comment>
         <rdfs:label xml:lang="en">Block</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -1725,7 +1725,7 @@
         <owl:annotatedTarget rdf:parseType="Collection">
             <rdf:Description rdf:about="http://ethon.consensys.net/blockHash"/>
         </owl:annotatedTarget>
-        <rdfs:comment xml:lang="en">The blockHash is the unique identifier of a Block. It is generated via the Keccak 256-bit hash of its Block header.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The blockHash is the unique identifier of a block. It is generated via the Keccak 256-bit hash of its block header.</rdfs:comment>
     </owl:Axiom>
 
 
@@ -1735,7 +1735,7 @@
     <owl:Class rdf:about="http://ethon.consensys.net/BlockConcept">
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/EthOnConcept"/>
         <suggestedStringRepresentation xml:lang="en">BlockConcept</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">The concept under which fall all EthOn concepts related to Blocks.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The concept under which fall all EthOn concepts related to blocks.</rdfs:comment>
         <rdfs:label xml:lang="en">EthOn Block concept</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -1747,7 +1747,7 @@
     <owl:Class rdf:about="http://ethon.consensys.net/Blockchain">
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/NetworkConcept"/>
         <suggestedStringRepresentation>Blockchain</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">An Ethereum Blockchain is a distributed database that maintains a continuously-growing list of records called *Blocks* secured from tampering and revision. Each Block contains a timestamp and a link to a previous Block in a Merkle tree structure.</rdfs:comment>
+        <rdfs:comment xml:lang="en">An Ethereum blockchain is a distributed database that maintains a continuously-growing list of records called *blocks* secured from tampering and revision. Each block contains a timestamp and a link to a previous block in a Merkle tree structure.</rdfs:comment>
         <rdfs:label xml:lang="en">Ethereum Blockchain</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>

--- a/EthOn.rdf
+++ b/EthOn.rdf
@@ -2024,7 +2024,7 @@
 
     <owl:Class rdf:about="http://ethon.consensys.net/MessageConcept">
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/EthOnConcept"/>
-        <rdfs:comment xml:lang="en">Groups EthOn concepts related to Messages.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Groups EthOn concepts related to messages.</rdfs:comment>
         <rdfs:label xml:lang="en">EthOn Message concept</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -2050,7 +2050,7 @@
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/MessageConcept"/>
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/StateTransition"/>
         <suggestedStringRepresentation>Msg</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Data (as a set of bytes) and value (specified as Ether) that is passed between two Accounts, either through the deterministic operation of an autonomous object (Contract Account) or the cryptographically secure signature of an External Account.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Data (as a set of bytes) and value (specified as Ether) that is passed between two accounts, either through the deterministic operation of an autonomous object (contract account) or the cryptographically secure signature of an external account.</rdfs:comment>
         <rdfs:label xml:lang="en">Message</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -2068,7 +2068,7 @@
     <owl:Class rdf:about="http://ethon.consensys.net/Network">
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/NetworkConcept"/>
         <suggestedStringRepresentation>Network</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">An Ethereum network is the group of all Nodes that conform to a certain Protocol Variant.</rdfs:comment>
+        <rdfs:comment xml:lang="en">An Ethereum network is the group of all nodes that conform to a certain protocol variant.</rdfs:comment>
         <rdfs:label xml:lang="en">Ethereum Network</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -2080,7 +2080,7 @@
     <owl:Class rdf:about="http://ethon.consensys.net/NetworkConcept">
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/EthOnConcept"/>
         <suggestedStringRepresentation>NetworkConcept</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Groups all EthOn Network concepts.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Groups all EthOn network concepts.</rdfs:comment>
         <rdfs:label xml:lang="en">EthOn Network Concept.</rdfs:label>
     </owl:Class>
 
@@ -2091,7 +2091,7 @@
     <owl:Class rdf:about="http://ethon.consensys.net/Node">
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/NetworkConcept"/>
         <suggestedStringRepresentation>Node</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A participan in an Ethereum Network.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A participant in an Ethereum network.</rdfs:comment>
         <rdfs:label xml:lang="en">Node</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -2126,7 +2126,7 @@
 
     <owl:Class rdf:about="http://ethon.consensys.net/ProtocolAccount">
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/Account"/>
-	<simpleDefinition>An account that was created together with the blockchain itself or during a protcol update and can have an initial balance, e.g. from the crowdfunding of the blockchain.</simpleDefinition>
+	      <simpleDefinition>An account that was created together with the blockchain itself or during a protcol update and can have an initial balance, e.g. from the crowdfunding of the blockchain.</simpleDefinition>
         <suggestedStringRepresentation xml:lang="en">PrefundedAccount</suggestedStringRepresentation>
         <rdfs:comment xml:lang="en">A protocol account is a type of account in Ethereum. Protocol accounts are specified in the Ethereum protocol, and have so far only been used to store the initial balance for users who participated in the Ethereum crowdsale. Protocol accounts could be added with any protocol change and may be either external accounts or contract accounts.</rdfs:comment>
         <rdfs:label xml:lang="en">Protocol Account</rdfs:label>
@@ -2140,7 +2140,7 @@
     <owl:Class rdf:about="http://ethon.consensys.net/ProtocolState">
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/AccountState"/>
         <suggestedStringRepresentation xml:lang="en">ProtocolState</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">This is a special state that can be created after specification of the protocol or any protocol change. It allows for setting balances of Accounts, e.g. for prefunded Accounts, creating predefined Contract Accounts with storage or setting any other state property as part of the protocol specification.</rdfs:comment>
+        <rdfs:comment xml:lang="en">This is a special state that can be created after specification of the protocol or any protocol change. It allows for setting balances of accounts, e.g. for prefunded accounts, creating predefined contract accounts with storage or setting any other state property as part of the protocol specification.</rdfs:comment>
         <rdfs:label xml:lang="en">ProtocolState</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -2166,7 +2166,7 @@
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/MessageConcept"/>
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/ModifiedMerklePatriciaTree"/>
         <suggestedStringRepresentation>ReceiptsTrie</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A trie structure that stores transaction receipts. Each Block has a reference to the root hash of a receipts trie that stores the receipts of the transactions included in the Block.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A trie structure that stores transaction receipts. Each block has a reference to the root hash of a receipts trie that stores the receipts of the transactions included in the block.</rdfs:comment>
         <rdfs:label xml:lang="en">Receipts Trie</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -2178,7 +2178,7 @@
     <owl:Class rdf:about="http://ethon.consensys.net/SelfdestructContractMsg">
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/ContractMsg"/>
         <suggestedStringRepresentation>SelfdestructContractMsg</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A Selfdestruct Contract Message is a Contract Message that deletes the originating contract and refunds its balance to the receiver of the Message.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A selfdestruct contract message is a contract message that deletes the originating contract and refunds its balance to the receiver of the message.</rdfs:comment>
         <rdfs:label xml:lang="en">Selfdestruct Contract Message</rdfs:label>
         <rdfs:seeAlso rdf:resource="https://github.com/ethereum/EIPs/blob/master/EIPS/eip-6.md"/>
         <ns:term_status>unstable</ns:term_status>
@@ -2237,7 +2237,7 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <suggestedStringRepresentation>Tx</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">Transactions are Messages between two Accounts that may transfer Ether and may contain a payload. Transactions always originate from an External Account that is controlled by an External Actor by means of a private key.  The execution of a Transaction creates a &apos;Transaction Receipt&apos;.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Transactions are messages between two accounts that may transfer Ether and may contain a payload. Transactions always originate from an external account that is controlled by an external actor by means of a private key.  The execution of a transaction creates a &apos;transaction receipt&apos;.</rdfs:comment>
         <rdfs:label xml:lang="en">Transaction</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -2257,7 +2257,7 @@
                 <owl:onClass rdf:resource="http://ethon.consensys.net/ExternalAccount"/>
             </owl:Restriction>
         </owl:annotatedTarget>
-        <rdfs:comment>All transactions originate from an External Account.</rdfs:comment>
+        <rdfs:comment>All transactions originate from an external account.</rdfs:comment>
     </owl:Axiom>
 
 
@@ -2281,7 +2281,7 @@
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/MessageConcept"/>
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/ModifiedMerklePatriciaTree"/>
         <suggestedStringRepresentation>TxTrie</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">A trie structure that stores transactions. The header of a Block contains a reference to the root of a Tx trie with all transactions contained in the Block.</rdfs:comment>
+        <rdfs:comment xml:lang="en">A trie structure that stores transactions. The header of a block contains a reference to the root of a Tx trie with all transactions contained in the block.</rdfs:comment>
         <rdfs:label xml:lang="en">Transactions Trie</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -2300,7 +2300,7 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <suggestedStringRepresentation xml:lang="en">Uncle</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">An Uncle is the direct child of the k&apos;th generation ancestor of a Block B, where 2&lt;=k&lt;=7 but not a direct ancestor of B. Uncles are blockchain blocks found by a miner, when a different miner has already found another block for the corresponding place in the blockchain. They are also known as “stale blocks”. The parent of an Uncle is an ancestor of the inserting block, located at the tip of the blockchain.</rdfs:comment>
+        <rdfs:comment xml:lang="en">An uncle is the direct child of the k&apos;th generation ancestor of a block B, where 2&lt;=k&lt;=7 but not a direct ancestor of B. Uncles are blockchain blocks found by a miner, when a different miner has already found another block for the corresponding place in the blockchain. They are also known as “stale blocks”. The parent of an uncle is an ancestor of the inserting block, located at the tip of the blockchain.</rdfs:comment>
         <rdfs:label xml:lang="en">Uncle</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>
@@ -2375,7 +2375,7 @@
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/ModifiedMerklePatriciaTree"/>
         <rdfs:subClassOf rdf:resource="http://ethon.consensys.net/State"/>
         <suggestedStringRepresentation xml:lang="en">State</suggestedStringRepresentation>
-        <rdfs:comment xml:lang="en">The world state, is a mapping between addresses (160-bit identifiers) of all Accounts and their States (a data structure serialised as Recursive Length Prefix). The mapping is not stored on the Blockchain itself but in a modified Merkle Patricia tree. An individual state is identified by the root hash of the trie.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The world state, is a mapping between addresses (160-bit identifiers) of all accounts and their states (a data structure serialised as Recursive Length Prefix). The mapping is not stored on the blockchain itself but in a modified Merkle Patricia tree. An individual state is identified by the root hash of the trie.</rdfs:comment>
         <rdfs:label xml:lang="en">World State</rdfs:label>
         <ns:term_status>unstable</ns:term_status>
     </owl:Class>


### PR DESCRIPTION
Update all definitions with more consistent capitalization scheme. Change all concept names appearing in definitions to lower case.